### PR TITLE
Fixed Failure text in Sandbox, for real this time

### DIFF
--- a/app/views/welcome/index.html.erb
+++ b/app/views/welcome/index.html.erb
@@ -693,7 +693,7 @@ var getCurrentLevelButton = function(levelIndex) {
     
     $( "#openerSBX" ).click(function() {
       $( "#csLevelGoal").html("<p>Sandbox - open play<br/> What will <b>you</b> make?</p>");
-      $csCurrentLevel = 999;
+      csCurrentLevel = 999;
     });
 
     $('#noIndColor').colorpicker({


### PR DESCRIPTION
Fixed a Failure Text that would show up in the sandbox level

Note: there is still this text if you:
1. play the sandbox,
2. leave codestitch and come back again
3. don't choose another level but continue at the sandbox (where the goal is no longer displayed, etc.)
